### PR TITLE
Use events for upgrade affordability checks

### DIFF
--- a/Coins & upgrades/CoinManager.cs
+++ b/Coins & upgrades/CoinManager.cs
@@ -85,6 +85,8 @@ public class CoinManager : MonoBehaviour {
     private CoinAmount totalCoins = new CoinAmount(0d, 0);
     private CoinAmount totalEnergy = new CoinAmount(0d, 0);
 
+    public event Action CurrencyChanged;
+
     private void Awake()
     {
         if (Instance != null && Instance != this)
@@ -105,6 +107,7 @@ public class CoinManager : MonoBehaviour {
     {
         totalCoins = CoinAmount.Add(totalCoins, amount);
         UpdateUI();
+        CurrencyChanged?.Invoke();
     }
 
     public bool UseCoins(CoinAmount amount) {
@@ -113,6 +116,7 @@ public class CoinManager : MonoBehaviour {
         if (success) {
             totalCoins = newTotal;
             UpdateUI();
+            CurrencyChanged?.Invoke();
         }
         return success;
     }
@@ -130,6 +134,7 @@ public class CoinManager : MonoBehaviour {
     {
         totalEnergy = CoinAmount.Add(totalEnergy, amount);
         UpdateUI();
+        CurrencyChanged?.Invoke();
     }
 
     public bool UseEnergy(CoinAmount amount) {
@@ -138,6 +143,7 @@ public class CoinManager : MonoBehaviour {
         if (success) {
             totalEnergy = newTotal;
             UpdateUI();
+            CurrencyChanged?.Invoke();
         }
         return success;
     }

--- a/Coins & upgrades/Upgrades/UpgradeButton.cs
+++ b/Coins & upgrades/Upgrades/UpgradeButton.cs
@@ -35,7 +35,7 @@ public class UpgradeButton : MonoBehaviour
         if (CoinManager.Instance.UseCoins(cost))
         {
             upgradeData.Upgrade();
-            upgradeData.upgradeCost = CalculateNextCost(upgradeData);
+            upgradeData.SetUpgradeCost(CalculateNextCost(upgradeData));
             upgradeObject.UpdateGenerationAmount();
             PickCheapestUpgrade();
             UpdateUI();

--- a/Coins & upgrades/Upgrades/UpgradeData.cs
+++ b/Coins & upgrades/Upgrades/UpgradeData.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 public enum UpgradeType {
@@ -26,10 +27,18 @@ public class UpgradeData : ScriptableObject
     public float costGrowthFactor = 1.12f;
     public float generationGrowthMultiplier = 1.06f;
 
+    public event Action<CoinAmount> CostChanged;
+
     public void Upgrade()
     {
         upgradeLevel++;
         generationAmount = CalculateNextGenerationAmount();
+    }
+
+    public void SetUpgradeCost(CoinAmount newCost)
+    {
+        upgradeCost = newCost;
+        CostChanged?.Invoke(upgradeCost);
     }
 
     public CoinAmount CalculateNextGenerationAmount()

--- a/Coins & upgrades/Upgrades/UpgradeMenuController.cs
+++ b/Coins & upgrades/Upgrades/UpgradeMenuController.cs
@@ -65,7 +65,7 @@ public class UpgradeMenuController : MonoBehaviour
         if (CoinManager.Instance.UseCoins(data.upgradeCost))
         {
             data.Upgrade();
-            data.upgradeCost = CalculateNextCost(data);
+            data.SetUpgradeCost(CalculateNextCost(data));
 
             // update generation on the spawned object
             var obj = upgradeManager.upgradeObjects.Find(o => o.data == data);

--- a/Coins & upgrades/Upgrades/UpgradeZone.cs
+++ b/Coins & upgrades/Upgrades/UpgradeZone.cs
@@ -5,19 +5,52 @@ public class UpgradeZone : MonoBehaviour {
     public int upgradeIndex;
     private UpgradeManager upgradeManager;
     public GameObject popupPrefab;
+    private UpgradeData data;
 
     void Awake() {
         upgradeManager = FindObjectOfType<UpgradeManager>();
     }
 
-    void Update() {
-        var data = upgradeManager.upgrades[upgradeIndex];
-        // only show if not obtained and player has enough coins
-        if (!data.isObtained && CoinManager.Instance.HasCoins(data.upgradeCost))
-        {
+    void OnEnable() {
+        data = upgradeManager.upgrades[upgradeIndex];
+        data.CostChanged += OnCurrencyOrPriceChanged;
+
+        if (CoinManager.Instance != null) {
+            CoinManager.Instance.CurrencyChanged += OnCurrencyOrPriceChanged;
+            CheckAffordable();
+        } else {
+            StartCoroutine(WaitForCoinManager());
+        }
+    }
+
+    private System.Collections.IEnumerator WaitForCoinManager() {
+        yield return new WaitUntil(() => CoinManager.Instance != null);
+        CoinManager.Instance.CurrencyChanged += OnCurrencyOrPriceChanged;
+        CheckAffordable();
+    }
+
+    void OnDisable() {
+        StopAllCoroutines();
+        if (CoinManager.Instance != null)
+            CoinManager.Instance.CurrencyChanged -= OnCurrencyOrPriceChanged;
+        if (data != null)
+            data.CostChanged -= OnCurrencyOrPriceChanged;
+    }
+
+    private void OnCurrencyOrPriceChanged() {
+        CheckAffordable();
+    }
+
+    private void OnCurrencyOrPriceChanged(CoinAmount _) {
+        CheckAffordable();
+    }
+
+    private void CheckAffordable() {
+        if (!data.isObtained && CoinManager.Instance.HasCoins(data.upgradeCost)) {
             var popup = Instantiate(popupPrefab, transform.position + Vector3.up * 2f, Quaternion.identity);
             popup.GetComponent<UpgradePopup>().Initialize(upgradeIndex, data, upgradeManager);
-            GetComponent<UpgradeZone>().enabled = false;
+            enabled = false;
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- add `CurrencyChanged` event to `CoinManager`
- add `CostChanged` event and `SetUpgradeCost` in `UpgradeData`
- replace per-frame `UpgradeZone` checks with event-driven logic
- delay `UpgradeZone` event hookup until `CoinManager` is initialized
- update upgrade purchase paths to trigger cost change events

## Testing
- `mcs -target:library $(find . -name '*.cs')` *(command not found)*
- `dotnet build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c096d310832f8e037aa8a9300fe0