### PR TITLE
feat: add auto collect unlock for upgrades

### DIFF
--- a/Coins & upgrades/Collectable.cs
+++ b/Coins & upgrades/Collectable.cs
@@ -5,10 +5,11 @@ using System.Collections;
 public class Collectable : MonoBehaviour
 {
     [SerializeField] private CollectableType collectableType;
-    [SerializeField] private int frequency = 1; // how often does it appear after deactivating in seconds 
+    [SerializeField] private int frequency = 1; // how often does it appear after deactivating in seconds
     [SerializeField] private TMP_Text flyTextAmount;
     [SerializeField] public CoinAmount amountToCollect;
     private Animator anim;
+    private bool isAutoCollecting = false;
 
     public enum CollectableType { Exp, Energy };
 
@@ -39,10 +40,23 @@ public class Collectable : MonoBehaviour
         StartCoroutine(WaitAndActivate(frequency));
     }
 
+    public void EnableAutoCollect()
+    {
+        if (isAutoCollecting) return;
+        isAutoCollecting = true;
+        Collect();
+    }
+
+    public bool IsAutoCollecting => isAutoCollecting;
+
     private IEnumerator WaitAndActivate(float waitTime)
     {
         yield return new WaitForSeconds(waitTime);
         anim.SetTrigger("Activate");
+        if (isAutoCollecting)
+        {
+            Collect();
+        }
     }
 
 }

--- a/Coins & upgrades/Upgrades/UpgradeData.cs
+++ b/Coins & upgrades/Upgrades/UpgradeData.cs
@@ -24,6 +24,7 @@ public class UpgradeData : ScriptableObject
     public CoinAmount generationAmount;
     public bool isObtained = false;
     public int upgradeLevel = 1;
+    public int autoCollectUnlockLevel = 0; // level at which auto collect starts
     public float costGrowthFactor = 1.12f;
     public float generationGrowthMultiplier = 1.06f;
 

--- a/Coins & upgrades/Upgrades/UpgradeObject.cs
+++ b/Coins & upgrades/Upgrades/UpgradeObject.cs
@@ -14,8 +14,12 @@ public class UpgradeObject : MonoBehaviour
             Debug.Log("[UpgradeObject.cs] CollectableScript not found!!!");
     }
 
-    public void UpdateGenerationAmount() 
+    public void UpdateGenerationAmount()
     {
         collectable.amountToCollect = data.generationAmount;
+        if (!collectable.IsAutoCollecting && data.autoCollectUnlockLevel > 0 && data.upgradeLevel >= data.autoCollectUnlockLevel)
+        {
+            collectable.EnableAutoCollect();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add configurable auto-collect unlock level to upgrade data
- enable collectables to auto-collect based on frequency once unlocked
- trigger auto-collect in upgrade objects when level threshold is reached

## Testing
- `dotnet build` (fails: command not found)
- `apt-get update` (fails: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_6896cd85cb94832fb47b758970fc5969